### PR TITLE
Fix for postgres container not allowing connections within a docker network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -152,6 +152,7 @@ services:
     restart: always
     env_file:
       - ./config/env/cyphon.env
+    command: sh -c "echo \"host all all 0.0.0.0/0 md5\" >> /var/lib/postgresql/data/pg_hba.conf && /docker-entrypoint.sh postgres"
 
   # RabbitMQ message broker for Cyphon and Logstash
   rabbit:


### PR DESCRIPTION
0.0.0.0/0 is wide open, but the postgres container doesn't export any ports, and this seems to be necessary to get the Cyphon container to be able to auth with the linked postgres container in a recent Docker environment (17.12.0 on Ubuntu 16.04).